### PR TITLE
紹介文用ドメインのリポジトリの定義を追加

### DIFF
--- a/feature/intro/build.gradle.kts
+++ b/feature/intro/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":utils"))
+
     implementation(libs.datetime)
     implementation(libs.bundles.test)
 }

--- a/feature/intro/src/main/kotlin/net/oucrc/domain/ReceivedMessage.kt
+++ b/feature/intro/src/main/kotlin/net/oucrc/domain/ReceivedMessage.kt
@@ -1,5 +1,7 @@
 package net.oucrc.domain
 
+import net.oucrc.domain.user.User
+
 data class ReceivedMessage(
     val user: User,
     val content: ReceivedContent,

--- a/feature/intro/src/main/kotlin/net/oucrc/domain/exception/DomainException.kt
+++ b/feature/intro/src/main/kotlin/net/oucrc/domain/exception/DomainException.kt
@@ -1,0 +1,3 @@
+package net.oucrc.domain.exception
+
+sealed class DomainException : Exception()

--- a/feature/intro/src/main/kotlin/net/oucrc/domain/introduction/Introduction.kt
+++ b/feature/intro/src/main/kotlin/net/oucrc/domain/introduction/Introduction.kt
@@ -1,4 +1,4 @@
-package net.oucrc.domain
+package net.oucrc.domain.introduction
 
 import kotlinx.datetime.Instant
 

--- a/feature/intro/src/main/kotlin/net/oucrc/domain/introduction/IntroductionRepository.kt
+++ b/feature/intro/src/main/kotlin/net/oucrc/domain/introduction/IntroductionRepository.kt
@@ -1,0 +1,9 @@
+package net.oucrc.domain.introduction
+
+import net.oucrc.ApiResult
+import net.oucrc.domain.exception.DomainException
+
+interface IntroductionRepository {
+    suspend fun getAll(): ApiResult<List<Introduction>, DomainException>
+    suspend fun upsert(introduction: Introduction): ApiResult<Unit, DomainException>
+}

--- a/feature/intro/src/main/kotlin/net/oucrc/domain/user/User.kt
+++ b/feature/intro/src/main/kotlin/net/oucrc/domain/user/User.kt
@@ -1,4 +1,4 @@
-package net.oucrc.domain
+package net.oucrc.domain.user
 
 class User(
     val id: UserId,

--- a/feature/intro/src/main/kotlin/net/oucrc/domain/user/UserRepository.kt
+++ b/feature/intro/src/main/kotlin/net/oucrc/domain/user/UserRepository.kt
@@ -1,0 +1,10 @@
+package net.oucrc.domain.user
+
+import net.oucrc.ApiResult
+import net.oucrc.domain.exception.DomainException
+
+interface UserRepository {
+    suspend fun getAll(): ApiResult<List<User>, DomainException>
+    suspend fun getById(userId: UserId): ApiResult<User, DomainException>
+    suspend fun upsert(user: User): ApiResult<Unit, DomainException>
+}


### PR DESCRIPTION
## チェックリスト

- [x] Ktlintを実行する(`./gradlew ktlintFormat`)
- [x] テストを通す(`./gradlew test`)
- [x] 不必要なコードを削除する(コマンドラインからPushする場合)
- [x] プルリクエストの名前をわかりやすく変更する
- [x] 下の欄を埋める

# 概要

紹介用ドメインのリポジトリの定義を追加
その際にファイルの括りを修正

Close #5 

### 実装したところ

IntroductionInterfaceを実装
UserInterfaceを実装
domainがutilsを使えるように変更
パッケージ構成を変更

### 懸念点

特になし